### PR TITLE
chore: downgrade fs-lock to v0.1.10

### DIFF
--- a/rust/fedimintd_mobile/Cargo.lock
+++ b/rust/fedimintd_mobile/Cargo.lock
@@ -2493,9 +2493,22 @@ dependencies = [
 
 [[package]]
 name = "fs-lock"
-version = "0.1.11"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe8007099aa47bbb6db591a80b992ba9da3241b086647b8e1d318d8317882c6"
+checksum = "7b4f2056716254938d208ed159fdd08d9d5f6fc208568fd80a5d8a69d3614b96"
+dependencies = [
+ "fs4",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.2",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fs_extra"


### PR DESCRIPTION
Seems like `fs-lock` `v0.1.11` has a problem, it does not work on Android. This fixes it by downgrading to `v0.1.10`